### PR TITLE
fix --pool-margin syntax register-stake-pool.md

### DIFF
--- a/create-a-stake-pool/register-stake-pool.md
+++ b/create-a-stake-pool/register-stake-pool.md
@@ -77,7 +77,7 @@ cardano-cli stake-pool registration-certificate \
 --vrf-verification-key-file vrf.vkey \
 --pool-pledge 9000000000 \
 --pool-cost 340000000 \
---pool-margin .05 \
+--pool-margin 0.05 \
 --pool-reward-account-verification-key-file stake.vkey \
 --pool-owner-stake-verification-key-file stake.vkey \
 --testnet-magic 2 \


### PR DESCRIPTION
Pool margin needs leading zero in front of the decimal, else the command fails with the takeWhile1 read error